### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/szymonos/9c5ef2ed-81c3-49d9-802a-f425cded87ab/52b1edfc-d00f-4eef-9494-4ea65c4697d8/_apis/work/boardbadge/e65b3acb-00f1-48ee-9fb4-48cb18709b14)](https://dev.azure.com/szymonos/9c5ef2ed-81c3-49d9-802a-f425cded87ab/_boards/board/t/52b1edfc-d00f-4eef-9494-4ea65c4697d8/Microsoft.RequirementCategory)
 # CommandAPI


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#5](https://dev.azure.com/szymonos/9c5ef2ed-81c3-49d9-802a-f425cded87ab/_workitems/edit/5). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.